### PR TITLE
Update static pages and improve navigation layout

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,3 +24,9 @@ body, button, input, select, textarea {
 .menu-item:hover {
   color: blue;
 }
+
+.container {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,2 @@
 class ApplicationController < ActionController::Base
-  def hello
-    render html: "Hello world!"
-  end
-
-  def contact
-    render html: "Contact page"
-  end
-
-  def projects
-    render html: "Project"
-  end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,20 +1,18 @@
 class StaticPagesController < ApplicationController
   def home
+    @currentTime = Time.now
+    @formatted_currentTime = @currentTime.strftime("%H:%M %d/%m/%Y")
   end
 
   def about
-    render html: "About page"
   end
 
   def projects
-    render html: "Projects page"
   end
 
   def contact
-    render html: "Contact page"
   end
 
   def resume
-    render html: "Resume page"
   end
 end

--- a/app/views/static_pages/_navbar.html.erb
+++ b/app/views/static_pages/_navbar.html.erb
@@ -1,10 +1,10 @@
 <div id="menu">
   <div id="menu-items">
-    <a href="/" class="menu-item">Home</a>
-    <a href="/" class="menu-item">About</a>
-    <a href="/" class="menu-item">Projects</a>
-    <a href="/" class="menu-item">Contact</a>
-    <a href="/" class="menu-item">Resume</a>
+    <%= link_to 'Home', root_path, class: 'menu-item' %>
+    <%= link_to 'About', about_path, class: 'menu-item' %>
+    <%= link_to 'Projects', projects_path, class: 'menu-item' %>
+    <%= link_to 'Contact', contact_path, class: 'menu-item' %>
+    <%= link_to 'Resume', resume_path, class: 'menu-item' %>
   </div>
   <div id="menu-background-pattern"></div>
 </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,0 +1,3 @@
+<div class="container">
+  <%= @formatted_currentTime %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
   # get 'static_pages/home'
   get 'about', to: 'static_pages#about'
-  get 'projects', to: 'application#projects'
-  get 'contact', to: 'application#contact'
+  get 'projects', to: 'static_pages#projects'
+  get 'contact', to: 'static_pages#contact'
+  get 'resume', to: 'static_pages#resume'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
This commit updates the display content and routing for the static pages in the application as follows: 'home', 'about', 'projects', 'contact', and 'resume'. The home page now shows the current time. The underlying HTML for the static pages was removed, and the correct links for navigation have been applied. Improved CSS styling has also been added to application.css to better present the content layout.